### PR TITLE
Added cancelled_at and removed active in subscriptions.

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -26,6 +26,6 @@ class SubscriptionsController < ApplicationController
   private
 
     def subscription_params
-      params.require(:subscription).permit(:oid, :plan_id, :customer_id, :active, :quantity, :started_at)
+      params.require(:subscription).permit(:oid, :plan_id, :customer_id, :cancelled_at, :quantity, :started_at)
     end
 end

--- a/app/javascript/components/subscriptions/subscription_form.vue
+++ b/app/javascript/components/subscriptions/subscription_form.vue
@@ -68,7 +68,7 @@ export default {
         id: null,
         oid: null,
         quantity: 1,
-        active: true,
+        cancelled_at: null,
         started_at: null,
         customer_id: null,
         plan_id: null,
@@ -91,7 +91,7 @@ export default {
   },
   created: function () {
     this.subscription.quantity = 1
-    this.subscription.active = true
+    this.subscription.cancelled_at = null
 
     Cable.subscriptions(this) // Subscribe to updating subscriptions in real time
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -14,15 +14,15 @@ end
 #
 # Table name: subscriptions
 #
-#  id          :bigint(8)        not null, primary key
-#  active      :boolean
-#  oid         :string
-#  quantity    :integer
-#  started_at  :datetime
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  customer_id :bigint(8)
-#  plan_id     :bigint(8)
+#  id           :bigint(8)        not null, primary key
+#  cancelled_at :datetime
+#  oid          :string
+#  quantity     :integer
+#  started_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  customer_id  :bigint(8)
+#  plan_id      :bigint(8)
 #
 # Indexes
 #

--- a/db/migrate/20180604105805_add_cancelled_at_and_remove_active_from_subscriptions.rb
+++ b/db/migrate/20180604105805_add_cancelled_at_and_remove_active_from_subscriptions.rb
@@ -1,0 +1,6 @@
+class AddCancelledAtAndRemoveActiveFromSubscriptions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriptions, :cancelled_at, :datetime
+    remove_column :subscriptions, :active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_28_121605) do
+ActiveRecord::Schema.define(version: 2018_06_04_105805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,9 +45,9 @@ ActiveRecord::Schema.define(version: 2018_05_28_121605) do
     t.bigint "plan_id"
     t.datetime "started_at"
     t.integer "quantity"
-    t.boolean "active"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "cancelled_at"
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["oid"], name: "index_subscriptions_on_oid"
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"

--- a/test/controllers/subscriptions_controller_test.rb
+++ b/test/controllers/subscriptions_controller_test.rb
@@ -9,7 +9,7 @@ class SubscriptionsControllerTest < ActionDispatch::IntegrationTest
   test "should create a subscription" do
     random_oid = SecureRandom.hex
     assert_difference('Subscription.count') do
-      post subscriptions_url, params: { subscription: { oid: random_oid, plan_id: plans(:one).id, customer_id: customers(:one).id, active: true, started_at: Time.now, quantity: 1 } }
+      post subscriptions_url, params: { subscription: { oid: random_oid, plan_id: plans(:one).id, customer_id: customers(:one).id, started_at: Time.now, quantity: 1 } }
     end
 
     assert_response :success
@@ -20,19 +20,19 @@ class SubscriptionsControllerTest < ActionDispatch::IntegrationTest
 
   test "should update a subscription" do
     subscription = subscriptions(:one)
-    active = false
+    cancelled_at = 1.second.ago
     quantity = 2
     
-    assert_not_equal active, subscription.active
+    assert_not_equal cancelled_at, subscription.cancelled_at
     assert_not_equal quantity, subscription.quantity
     
-    patch subscription_path(subscription), params: { subscription: { active: false, quantity: 2 } }
+    patch subscription_path(subscription), params: { subscription: { cancelled_at: cancelled_at, quantity: 2 } }
 
     assert_response :success
 
     subscription.reload
 
-    assert_equal active, subscription.active
+    assert_in_delta cancelled_at, subscription.cancelled_at, 1.second
     assert_equal quantity, subscription.quantity
   end
 end

--- a/test/fixtures/subscriptions.yml
+++ b/test/fixtures/subscriptions.yml
@@ -5,7 +5,7 @@ one:
   plan: one
   started_at: 2018-05-28 17:46:05
   quantity: 1
-  active: true
+  cancelled_at: null
   oid: one
 
 two:
@@ -13,22 +13,22 @@ two:
   plan: two
   started_at: 2018-05-28 17:46:05
   quantity: 1
-  active: false
+  cancelled_at: <%= 2.days.ago %>
   oid: two
 
 # == Schema Information
 #
 # Table name: subscriptions
 #
-#  id          :bigint(8)        not null, primary key
-#  active      :boolean
-#  oid         :string
-#  quantity    :integer
-#  started_at  :datetime
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  customer_id :bigint(8)
-#  plan_id     :bigint(8)
+#  id           :bigint(8)        not null, primary key
+#  cancelled_at :datetime
+#  oid          :string
+#  quantity     :integer
+#  started_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  customer_id  :bigint(8)
+#  plan_id      :bigint(8)
 #
 # Indexes
 #

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -13,15 +13,15 @@ end
 #
 # Table name: subscriptions
 #
-#  id          :bigint(8)        not null, primary key
-#  active      :boolean
-#  oid         :string
-#  quantity    :integer
-#  started_at  :datetime
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  customer_id :bigint(8)
-#  plan_id     :bigint(8)
+#  id           :bigint(8)        not null, primary key
+#  cancelled_at :datetime
+#  oid          :string
+#  quantity     :integer
+#  started_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  customer_id  :bigint(8)
+#  plan_id      :bigint(8)
 #
 # Indexes
 #


### PR DESCRIPTION
To better manage subscriptions. Just an `active` field is not enough. Having a `cancelled_at` field allows us to better context of subscriptions, and helps a lot in calculating churn.